### PR TITLE
feat(mongodb): add skip_ping_at_init option

### DIFF
--- a/plugins/inputs/mongodb/README.md
+++ b/plugins/inputs/mongodb/README.md
@@ -39,6 +39,10 @@ All MongoDB server versions from 2.6 and higher are supported.
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+
+  ## Skip Ping at initialization
+  ## If you are not sure that your mongodb is already running, skipping the ping operation will allow you to run Telegraf normally and mongodb will try to reconnect by itself
+  # skip_ping_at_init = false
 ```
 
 ### Permissions

--- a/plugins/inputs/mongodb/mongodb.go
+++ b/plugins/inputs/mongodb/mongodb.go
@@ -32,6 +32,7 @@ type MongoDB struct {
 	GatherPerdbStats    bool
 	GatherColStats      bool
 	GatherTopStat       bool
+	SkipPingAtInit      bool
 	ColStatsDbs         []string
 	tlsint.ClientConfig
 
@@ -108,9 +109,10 @@ func (m *MongoDB) Init() error {
 			return fmt.Errorf("unable to connect to MongoDB: %q", err)
 		}
 
-		err = client.Ping(ctx, opts.ReadPreference)
-		if err != nil {
-			return fmt.Errorf("unable to connect to MongoDB: %s", err)
+		if m.SkipPingAtInit {
+			m.Log.Infof("skip ping at initialization to MongoDB: %q", connURL)
+		} else if err := client.Ping(ctx, opts.ReadPreference); err != nil {
+			return fmt.Errorf("unable to ping to MongoDB: %s", err)
 		}
 
 		server := &Server{

--- a/plugins/inputs/mongodb/mongodb_skip_test.go
+++ b/plugins/inputs/mongodb/mongodb_skip_test.go
@@ -1,0 +1,20 @@
+package mongodb
+
+import (
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMongodb_SkipPingAtInit(t *testing.T) {
+	m := &MongoDB{
+		Log:     testutil.Logger{},
+		Servers: []string{"mongodb://aaa:bbb@127.0.0.1:37017/adminaaa"},
+	}
+	err := m.Init()
+	assert.Error(t, err)
+	m.SkipPingAtInit = true
+	err = m.Init()
+	assert.NoError(t, err)
+}

--- a/plugins/inputs/mongodb/sample.conf
+++ b/plugins/inputs/mongodb/sample.conf
@@ -32,3 +32,6 @@
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+
+  ## Skip Ping at initialization
+  # skip_ping_at_init = true


### PR DESCRIPTION
### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #10078

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

### Summary
add skip_ping_at_init option for mongodb input
If you are not sure that your mongodb is already running, skipping the ping operation will allow you to run Telegraf normally and mongodb will try to reconnect by itself